### PR TITLE
Change input format to prevent users to break parser

### DIFF
--- a/src/main/java/cooper/ui/ParserUi.java
+++ b/src/main/java/cooper/ui/ParserUi.java
@@ -12,7 +12,7 @@ public class ParserUi extends Ui {
             + System.getProperty("user.dir") + "/tmp" + "/tmp_file_command.txt" + " or "
             + System.getProperty("user.dir") + "/tmp" + "/tmp_file_training.txt";
     private static final String INVALID_COMMAND_FORMAT = "The command you entered is of the wrong format!";
-    private static final String PLEASE_ENTER_NUMBER = "Please enter a valid number for the argument!";
+    private static final String PLEASE_ENTER_NUMBER = "Please enter a valid number (0 to 99999999) for the argument!";
 
     /**
      * Informs user that an unrecognised command ha been entered.

--- a/src/main/java/cooper/ui/ParserUi.java
+++ b/src/main/java/cooper/ui/ParserUi.java
@@ -12,7 +12,7 @@ public class ParserUi extends Ui {
             + System.getProperty("user.dir") + "/tmp" + "/tmp_file_command.txt" + " or "
             + System.getProperty("user.dir") + "/tmp" + "/tmp_file_training.txt";
     private static final String INVALID_COMMAND_FORMAT = "The command you entered is of the wrong format!";
-    private static final String PLEASE_ENTER_NUMBER = "Please enter a number for the argument.";
+    private static final String PLEASE_ENTER_NUMBER = "Please enter a valid number for the argument!";
 
     /**
      * Informs user that an unrecognised command ha been entered.

--- a/src/main/java/cooper/ui/Ui.java
+++ b/src/main/java/cooper/ui/Ui.java
@@ -35,8 +35,8 @@ public class Ui {
     private static final String EMPTY_STRING = "";
 
     protected static final String LOGIN_REGISTER_FOR_ACCESS = "Log in or register to gain access to my features!";
-    protected static final String LOGIN = "To log in, enter \"login [yourUsername] pw [password] as [yourRole]\".";
-    protected static final String REGISTER = "To register, enter \"register [yourUsername] pw [password] as "
+    protected static final String LOGIN = "To log in, enter \"login [yourUsername] /pw [password] /as [yourRole]\".";
+    protected static final String REGISTER = "To register, enter \"register [yourUsername] /pw [password] /as "
             + "[yourRole]\".";
     protected static final String EXIT = "To exit, enter \"exit\".";
 
@@ -54,7 +54,7 @@ public class Ui {
     private static final String ADD_FORMAT      = "| add           | add [amount]";
     private static final String LIST_FORMAT     = "| list          | list";
     private static final String GENERATE_FORMAT = "| generate      | generate [financialStatement]";
-    private static final String SCHEDULE_FORMAT = "| schedule      | schedule [meetingName] with [username1], "
+    private static final String SCHEDULE_FORMAT = "| schedule      | schedule [meetingName] /with [username1], "
             + "[username2] /at [meetingTime]";
 
     /* Constants used for employee help command */
@@ -62,7 +62,7 @@ public class Ui {
             + "formats:";
     private static final String POST_ADD_FORMAT     = "| post add      | post add [postContent]";
     private static final String POST_DELETE_FORMAT  = "| post delete   | post delete [postId]";
-    private static final String POST_COMMENT_FORMAT = "| post comment  | post comment [commentContent] on [postId]";
+    private static final String POST_COMMENT_FORMAT = "| post comment  | post comment [commentContent] /on [postId]";
     private static final String POST_LIST_FORMAT    = "| post list     | post list all / post list [postId]";
     private static final String AVAILABLE_FORMAT    = "| available     | available [availableTime]";
     private static final String AVAILABILITY_FORMAT = "| availability  | availability";

--- a/src/main/resources/parser/command-data.properties
+++ b/src/main/resources/parser/command-data.properties
@@ -14,13 +14,13 @@ postAdd = post add ${content-hint}
 postDelete = post delete ${index-hint}
 
 # post comment
-postComment = post comment ${content-hint} on ${index-hint}
+postComment = post comment ${content-hint} /on ${index-hint}
 
 # post list
 postList = post list ${list-hint}
 
 # schedule
-schedule = schedule ${meeting-hint} with ${usernames-hint}
+schedule = schedule ${meeting-hint} /with ${usernames-hint}
 
 # generate pdf
 generate = generate ${document-hint}

--- a/src/main/resources/parser/sign-in-data.properties
+++ b/src/main/resources/parser/sign-in-data.properties
@@ -1,5 +1,5 @@
 #login
-login = login ${username-hint} pw ${password-hint} as ${role-hint}
+login = login ${username-hint} /pw ${password-hint} /as ${role-hint}
 
 #register
-register = register ${username-hint} pw ${password-hint} as ${role-hint}
+register = register ${username-hint} /pw ${password-hint} /as ${role-hint}

--- a/src/test/java/cooper/parser/ParserTest.java
+++ b/src/test/java/cooper/parser/ParserTest.java
@@ -49,9 +49,9 @@ public class ParserTest {
     @Test
     void parseSignInDetails_invalidRole_throwsInvalidUserRoleException() {
         assertThrows(InvalidUserRoleException.class, () ->
-                SignInDetailsParser.parse("login Topias pw 1111 as abc"));
+                SignInDetailsParser.parse("login Topias /pw 1111 /as abc"));
 
         assertThrows(InvalidUserRoleException.class, () ->
-                SignInDetailsParser.parse("register Martin pw 1111 as boss"));
+                SignInDetailsParser.parse("register Martin /pw 1111 /as boss"));
     }
 }

--- a/src/test/java/cooper/verification/VerifierTest.java
+++ b/src/test/java/cooper/verification/VerifierTest.java
@@ -23,7 +23,7 @@ public class VerifierTest {
     @Test
     @Order(1)
     void verify_properInputFirstLoginAttempt_loginFailed() {
-        String input = "login Topias pw 1111 as admin";
+        String input = "login Topias /pw 1111 /as admin";
         SignInDetails actual = verifier.verify(input);
         assertFalse(verifier.isSuccessfullySignedIn());
     }
@@ -31,7 +31,7 @@ public class VerifierTest {
     @Test
     @Order(2)
     void verify_properInputRegisterUser_registrationSuccessful() {
-        String input = "register Martin pw 1111 as admin";
+        String input = "register Martin /pw 1111 /as admin";
         SignInDetails actual = verifier.verify(input);
 
         String userSalt = verifier.getRegisteredUsers().get("Martin").getUserSalt();
@@ -44,7 +44,7 @@ public class VerifierTest {
     @Test
     @Order(3)
     void verify_properInputLoginAfterRegister_loginSuccessful() {
-        String input = "register Martin pw 1111 as admin";
+        String input = "register Martin /pw 1111 /as admin";
         SignInDetails actual = verifier.verify(input);
 
         String userSalt = verifier.getRegisteredUsers().get("Martin").getUserSalt();
@@ -52,7 +52,7 @@ public class VerifierTest {
         SignInDetails expected = new SignInDetails("Martin", userEncryptedPassword, userSalt, UserRole.ADMIN);
         assertTrue(hasSameAttributeValuesAs(actual, expected));
 
-        input = "login Martin pw 1111 as admin";
+        input = "login Martin /pw 1111 /as admin";
         actual = verifier.verify(input);
 
         assertTrue(verifier.isSuccessfullySignedIn());
@@ -61,7 +61,7 @@ public class VerifierTest {
     @Test
     @Order(4)
     void verify_wrongPasswordLoginAfterRegister_loginUnsuccessful() {
-        String input = "login Martin pw 1234 as admin";
+        String input = "login Martin /pw 1234 /as admin";
         SignInDetails actual = verifier.verify(input);
 
         String userSalt = verifier.getRegisteredUsers().get("Martin").getUserSalt();
@@ -76,7 +76,7 @@ public class VerifierTest {
     @Test
     @Order(5)
     void verify_wrongRoleLoginAfterRegister_loginUnsuccessful() {
-        String input = "login Martin pw 1111 as employee";
+        String input = "login Martin /pw 1111 /as employee";
         SignInDetails actual = verifier.verify(input);
 
         String userSalt = verifier.getRegisteredUsers().get("Martin").getUserSalt();


### PR DESCRIPTION
#179 #173 #168 Changed commands of form `cmd ${input} cmd2 ${input2}` to `cmd ${input} /cmd2 ${input}`.

Basically, if there are reserved words in between user commands, user can break it by inputting these reserved words.

Affected commands:
+ schedule = schedule ${meeting-hint} /with ${usernames-hint}
+ login = login ${username-hint} /pw ${password-hint} /as ${role-hint}
+ register = register ${username-hint} /pw ${password-hint} /as ${role-hint}

The rest of the commands do not have the patterns as described above and hence would not break by users


