### PR TITLE
Removed universal getters in ResourcesManager

### DIFF
--- a/src/main/java/cooper/Cooper.java
+++ b/src/main/java/cooper/Cooper.java
@@ -74,10 +74,7 @@ public class Cooper {
         Ui.showIntroduction();
 
         // Load data from storage
-        cooperStorageManager.loadAllData(cooperVerifier,
-                cooperResourcesManager.getFinanceManager(),
-                cooperResourcesManager.getMeetingManager(),
-                cooperResourcesManager.getForumManager());
+        cooperStorageManager.loadAllData(cooperVerifier, cooperResourcesManager);
     }
 
     /**

--- a/src/main/java/cooper/command/AvailabilityCommand.java
+++ b/src/main/java/cooper/command/AvailabilityCommand.java
@@ -6,6 +6,7 @@ import cooper.resources.ResourcesManager;
 import cooper.storage.StorageManager;
 import cooper.ui.MeetingsUi;
 import cooper.verification.SignInDetails;
+import cooper.verification.UserRole;
 
 //@@author fansxx
 
@@ -23,7 +24,8 @@ public class AvailabilityCommand extends Command {
     @Override
     public void execute(SignInDetails signInDetails, ResourcesManager resourcesManager, 
                         StorageManager storageManager) throws InvalidAccessException {
-        MeetingManager meetingManager = resourcesManager.getMeetingManager();
+        UserRole userRole = signInDetails.getUserRole();
+        MeetingManager meetingManager = resourcesManager.getMeetingManager(userRole);
         MeetingsUi.printAvailabilities(meetingManager.getAvailability());
     }
 }

--- a/src/main/java/cooper/command/AvailableCommand.java
+++ b/src/main/java/cooper/command/AvailableCommand.java
@@ -9,6 +9,7 @@ import cooper.storage.StorageManager;
 import cooper.ui.MeetingsUi;
 import cooper.verification.SignInDetails;
 import cooper.resources.ResourcesManager;
+import cooper.verification.UserRole;
 
 //@@author fansxx
 
@@ -33,7 +34,8 @@ public class AvailableCommand extends Command {
     public void execute(SignInDetails signInDetails, ResourcesManager resourcesManager, StorageManager storageManager)
             throws InvalidAccessException {
         String username = signInDetails.getUsername();
-        MeetingManager meetingManager = resourcesManager.getMeetingManager();
+        UserRole userRole = signInDetails.getUserRole();
+        MeetingManager meetingManager = resourcesManager.getMeetingManager(userRole);
 
         try {
             meetingManager.addAvailability(dateTime, username);

--- a/src/main/java/cooper/command/BsCommand.java
+++ b/src/main/java/cooper/command/BsCommand.java
@@ -8,7 +8,6 @@ import cooper.parser.CommandParser;
 import cooper.resources.ResourcesManager;
 import cooper.storage.StorageManager;
 import cooper.ui.FinanceUi;
-import cooper.ui.Ui;
 import cooper.verification.SignInDetails;
 import cooper.verification.UserRole;
 

--- a/src/main/java/cooper/command/MeetingsCommand.java
+++ b/src/main/java/cooper/command/MeetingsCommand.java
@@ -6,6 +6,7 @@ import cooper.ui.MeetingsUi;
 import cooper.storage.StorageManager;
 import cooper.verification.SignInDetails;
 import cooper.resources.ResourcesManager;
+import cooper.verification.UserRole;
 
 //@@author fansxx
 
@@ -23,8 +24,9 @@ public class MeetingsCommand extends Command {
     @Override        
     public void execute(SignInDetails signInDetails, ResourcesManager resourcesManager,
                         StorageManager storageManager) throws InvalidAccessException {
+        UserRole userRole = signInDetails.getUserRole();
         String username = signInDetails.getUsername();
-        MeetingManager meetingManager = resourcesManager.getMeetingManager();
+        MeetingManager meetingManager = resourcesManager.getMeetingManager(userRole);
         MeetingsUi.printMeetings(meetingManager.getUserSpecificMeetings(username));
     }
 }

--- a/src/main/java/cooper/resources/ResourcesManager.java
+++ b/src/main/java/cooper/resources/ResourcesManager.java
@@ -46,7 +46,7 @@ public class ResourcesManager {
      * Use this give-receive pattern to get private members from ResourcesManager (Similar to friend class)
      * Pattern adepted from:
      * https://stackoverflow.com/questions/14226228/implementation-of-friend-concept-in-javat
-     */
+     **/
     public FinanceManager giveFinanceManager(StorageManager storageManager) {
         return storageManager.receiveFinanceManager(cooperFinanceManager);
     }

--- a/src/main/java/cooper/resources/ResourcesManager.java
+++ b/src/main/java/cooper/resources/ResourcesManager.java
@@ -2,6 +2,7 @@ package cooper.resources;
 
 import cooper.finance.FinanceManager;
 import cooper.meetings.MeetingManager;
+import cooper.storage.StorageManager;
 import cooper.forum.ForumManager;
 import cooper.verification.UserRole;
 
@@ -19,9 +20,6 @@ public class ResourcesManager {
         cooperForumManager = new ForumManager();
     }
 
-    public FinanceManager getFinanceManager() {
-        return cooperFinanceManager;
-    }
     
     public FinanceManager getFinanceManager(UserRole userRole) {
         if (userRole.equals(UserRole.ADMIN)) {
@@ -29,10 +27,6 @@ public class ResourcesManager {
         } else {
             return null;
         }
-    }
-
-    public MeetingManager getMeetingManager() {
-        return cooperMeetingManager;
     }
 
     public MeetingManager getMeetingManager(UserRole userRole) {
@@ -43,11 +37,26 @@ public class ResourcesManager {
         }
     }
 
-    public ForumManager getForumManager() {
-        return cooperForumManager;
-    }
-
     public ForumManager getForumManager(UserRole userRole) {
         return cooperForumManager;
     }
+
+    /**
+     * Storage class has "super privilege" to access private member in resources class.
+     * Use this give-receive pattern to get private members from ResourcesManager (Similar to friend class)
+     * Pattern adepted from:
+     * https://stackoverflow.com/questions/14226228/implementation-of-friend-concept-in-javat
+     */
+    public FinanceManager giveFinanceManager(StorageManager storageManager) {
+        return storageManager.receiveFinanceManager(cooperFinanceManager);
+    }
+
+    public MeetingManager giveMeetingManager(StorageManager storageManager) {
+        return storageManager.receiveMeetingManager(cooperMeetingManager);
+    }
+
+    public ForumManager giveForumManager(StorageManager storageManager) {
+        return storageManager.receiveForumManager(cooperForumManager);
+    }
+
 }

--- a/src/main/java/cooper/storage/StorageManager.java
+++ b/src/main/java/cooper/storage/StorageManager.java
@@ -6,6 +6,7 @@ import cooper.finance.FinanceManager;
 import cooper.meetings.MeetingManager;
 import cooper.forum.ForumManager;
 import cooper.verification.Verifier;
+import cooper.resources.ResourcesManager;
 
 //@@author theeugenechong
 
@@ -35,13 +36,18 @@ public class StorageManager {
         this.forumStorage = new ForumStorage(BASE_DIRECTORY + FORUM_FILE);
     }
 
-    public void loadAllData(Verifier cooperVerifier, FinanceManager cooperFinanceManager,
-                            MeetingManager cooperMeetingManager, ForumManager cooperForumManager) {
+    public void loadAllData(Verifier cooperVerifier, ResourcesManager resourcesManager) {
         signInDetailsStorage.loadSignInDetails(cooperVerifier);
+
+        FinanceManager cooperFinanceManager = resourcesManager.giveFinanceManager(this);
         cashFlowStorage.loadCashFlowStatement(cooperFinanceManager.cooperCashFlowStatement);
         balanceSheetStorage.loadBalanceSheet(cooperFinanceManager.cooperBalanceSheet);
+
+        MeetingManager cooperMeetingManager = resourcesManager.giveMeetingManager(this);
         availabilityStorage.loadAvailability(cooperMeetingManager);
         meetingsStorage.loadMeetings(cooperMeetingManager);
+
+        ForumManager cooperForumManager = resourcesManager.giveForumManager(this);
         forumStorage.loadForum(cooperForumManager);
     }
 
@@ -67,5 +73,24 @@ public class StorageManager {
 
     public void saveForum(ForumManager cooperForumManager) {
         forumStorage.saveForum(cooperForumManager);
+    }
+
+
+    /**
+     * Storage class has "super privilege" to access private member in resources class.
+     * Use this give-receive pattern to get private members from ResourcesManager (Similar to friend class)
+     * Pattern adepted from:
+     * https://stackoverflow.com/questions/14226228/implementation-of-friend-concept-in-javat
+     */
+    public FinanceManager receiveFinanceManager(FinanceManager financeManager) {
+        return financeManager;
+    }
+
+    public MeetingManager receiveMeetingManager(MeetingManager meetingManager) {
+        return meetingManager;
+    }
+
+    public ForumManager receiveForumManager(ForumManager forumManager) {
+        return forumManager;
     }
 }

--- a/src/main/java/cooper/storage/StorageManager.java
+++ b/src/main/java/cooper/storage/StorageManager.java
@@ -81,7 +81,7 @@ public class StorageManager {
      * Use this give-receive pattern to get private members from ResourcesManager (Similar to friend class)
      * Pattern adepted from:
      * https://stackoverflow.com/questions/14226228/implementation-of-friend-concept-in-javat
-     */
+     **/
     public FinanceManager receiveFinanceManager(FinanceManager financeManager) {
         return financeManager;
     }


### PR DESCRIPTION
`ResourcesManager` manages access rights to different features based on user role. There should not be universal getters to get feature managers. The reason why we have it previously is because `StorageManager` needs to access private members from `ResourcesManager`. 

Solution: 
+ Use give-receive pattern to pass private members from resources to storage class. This provides a safe way to pass references of private member from one class to another
+ Implementation adapted from https://stackoverflow.com/questions/14226228/implementation-of-friend-concept-in-javat